### PR TITLE
JMeter test result processing with error response code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ENV PATH $PATH:$JMETER_BIN
 # Entrypoint has same signature as "jmeter" command
 #COPY entrypoint.sh /
 WORKDIR	${JMETER_HOME}
-#ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["./entrypoint.sh"]
 
 # -----------------------------------------------------------------------
 # JMeter layer including plugins

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # JMeter base layer
 # inspired by https://hub.docker.com/r/justb4/jmeter
 # -----------------------------------------------------------------------
-FROM alpine:3.17.1 as jmeter-base
+FROM alpine:3.17.3 as jmeter-base
 
 LABEL maintainer="klehmann@aservo.com"
 
@@ -42,9 +42,9 @@ WORKDIR	${JMETER_HOME}
 # -----------------------------------------------------------------------
 FROM jmeter-base
 
-ARG JMETER_PLUGINS_MANAGER_VERSION=1.8
+ARG JMETER_PLUGINS_MANAGER_VERSION=1.9
 ARG CMDRUNNER_VERSION=2.3
-ARG PROMETHEUS_LISTERER_VERSION=0.6.0
+ARG PROMETHEUS_LISTERER_VERSION=0.6.2
 
 # install plugins not provided via plugin manager manually
 RUN curl -L --silent https://repo1.maven.org/maven2/com/github/johrstrom/jmeter-prometheus-plugin/${PROMETHEUS_LISTERER_VERSION}/jmeter-prometheus-plugin-${PROMETHEUS_LISTERER_VERSION}.jar -o ${JMETER_PLUGINS_FOLDER}/jmeter-prometheus-plugin-${PROMETHEUS_LISTERER_VERSION}.jar
@@ -57,7 +57,7 @@ RUN cd /tmp/ \
  && curl --location --silent --show-error --output ${JMETER_PLUGINS_FOLDER}/jmeter-plugins-manager-${JMETER_PLUGINS_MANAGER_VERSION}.jar http://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/${JMETER_PLUGINS_MANAGER_VERSION}/jmeter-plugins-manager-${JMETER_PLUGINS_MANAGER_VERSION}.jar \
  && curl --location --silent --show-error --output ${JMETER_HOME}/lib/cmdrunner-${CMDRUNNER_VERSION}.jar http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/${CMDRUNNER_VERSION}/cmdrunner-${CMDRUNNER_VERSION}.jar \
  && java -cp ${JMETER_HOME}/lib/ext/jmeter-plugins-manager-${JMETER_PLUGINS_MANAGER_VERSION}.jar org.jmeterplugins.repository.PluginManagerCMDInstaller \
- && PluginsManagerCMD.sh install jpgc-graphs-basic=2.0,jpgc-prmctl=0.4,jpgc-dummy=0.4,jpgc-functions=2.1,jpgc-webdriver=4.7.2 \
+ && PluginsManagerCMD.sh install jpgc-graphs-basic=2.0,jpgc-prmctl=0.4,jpgc-dummy=0.4,jpgc-functions=2.1,jpgc-webdriver=4.8.3.2 \
  && jmeter --version \
  && PluginsManagerCMD.sh status \
  && chmod +x ${JMETER_HOME}/bin/*.sh \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 Docker JMeter
 ==============
 
-A JMeter image including packaged with the JMeter plugins manager plus initialized plugins. In addition, the Prometheus Exporter plugin is included as well.
+A JMeter image packaged with the JMeter plugins manager plus initialized plugins. These are
+- JPGC Dummy Sampler
+- JPGC Basic Graphs
+- JPGC Parameterized Controllers
+- JPGC Functions
+- JPGC Webdriver 
+- Prometheus Listener
+
+> Note: The entrypoint script evaluates the run results and returns 0 for successful runs and 1 if any errors occurred. 
 
 ## Links
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,16 +13,17 @@ export JVM_ARGS="-Xmn${n}m -Xms${s}m -Xmx${x}m"
 
 echo "START Running Jmeter on `date`"
 echo "JVM_ARGS=${JVM_ARGS}"
-echo "jmeter args=$@"
+echo "JMeter args=$@"
 
-# Keep entrypoint simple: we must pass the standard JMeter arguments
-jmeter $@
+# Pass JMeter arguments and redirect stdout and err to file for checking whether or not the test was successful
+jmeter $@ 2>&1 | tee jmeter-output
 echo "END Running Jmeter on `date`"
 
-#     -n \
-#    -t "/tests/${TEST_DIR}/${TEST_PLAN}.jmx" \
-#    -l "/tests/${TEST_DIR}/${TEST_PLAN}.jtl"
-# exec tail -f jmeter.log
-#    -D "java.rmi.server.hostname=${IP}" \
-#    -D "client.rmi.localport=${RMI_PORT}" \
-#  -R $REMOTE_HOSTS
+# Evaluate jmeter process output
+if grep -q -E 'Err:.+[1-9]\W\(' jmeter-output
+then
+  echo "RESULT: test failed :-( - return code 1"
+  exit 1
+else
+  echo "RESULT: test suceeded :-) - return code 0"
+fi


### PR DESCRIPTION
This PR introduces an error return code (1) in case the executed test failed. Otherwise the return code remains 0, means all tests passed successfully. The intention of this new behavior is for easy integration in scripted environments, e.g. helm, where a step failure criteria is needed. (Note: by default JMeter returns 0 even if tests failed.)